### PR TITLE
✨ Feature/query all pokemon by name

### DIFF
--- a/src/__tests__/acceptance/pokemon.controller.acceptance.ts
+++ b/src/__tests__/acceptance/pokemon.controller.acceptance.ts
@@ -20,6 +20,16 @@ describe('PokemonController', () => {
       const res = await client.get('/pokemon').expect(200);
       expect(res.body).to.have.length(151);
     });
+
+    it('returns a list of Pokemon with the given name', async () => {
+      const res = await client.get('/pokemon?name=Bulbasaur').expect(200);
+      expect(res.body).to.have.length(1);
+    });
+
+    it('returns a list of Pokemon with partial name', async () => {
+      const res = await client.get('/pokemon?name=saur').expect(200);
+      expect(res.body).to.have.length(3);
+    });
   });
 
   describe('invokes GET /pokemon/{id}', () => {

--- a/src/controllers/pokemon.controller.ts
+++ b/src/controllers/pokemon.controller.ts
@@ -34,8 +34,10 @@ export class PokemonController {
       },
     },
   })
-  async find(): Promise<Pokemon[]> {
-    return this.pokemonService.findAll();
+  async find(
+    @param.query.string('name') name?: string,
+  ): Promise<Pokemon[]> {
+    return this.pokemonService.findAll({name});
   }
 
   @get('/pokemon/{id}')

--- a/src/services/pokemon.service.ts
+++ b/src/services/pokemon.service.ts
@@ -16,8 +16,14 @@ export class PokemonService {
     public pokemonRepository: PokemonRepository,
   ) {}
 
-  findAll(filter?: PokemonQueryParams): Promise<Pokemon[]> {
-    return this.pokemonRepository.find();
+  findAll({name}: PokemonQueryParams): Promise<Pokemon[]> {
+    return name
+      ? this.pokemonRepository.find({
+          where: {
+            name: {like: new RegExp('.*' + name + '.*', 'i')},
+          },
+        })
+      : this.pokemonRepository.find();
   }
 
   async findById(id: string): Promise<Pokemon> {


### PR DESCRIPTION
Enable name property at query param at `GET` `/pokemon` endpoint.
* ✅ define use cases given a query param name
* ✨ customise query to pick the name from given params and filter by it
* ✨ add name query param to the query pokemon endpoint