### PR TITLE
✨ Feature/query all pokemon by favourite

### DIFF
--- a/src/__tests__/acceptance/pokemon.controller.acceptance.ts
+++ b/src/__tests__/acceptance/pokemon.controller.acceptance.ts
@@ -55,6 +55,42 @@ describe('PokemonController', () => {
         expect(pokemon.types).to.have.containEql(type);
       });
     });
+
+    it('return a list of favourite Pokemon', async () => {
+      const favouritesPokemon = ['004', '59', '135'];
+      await Promise.all(
+        favouritesPokemon.map(pokemonId =>
+          client.put(
+            `/pokemon/${pokemonId}/favourite/${FavouriteActions.Mark}`,
+          ),
+        ),
+      );
+      const res = await client.get(`/pokemon?favourite=true`).expect(200);
+      res.body.forEach((pokemon: Pokemon) => {
+        expect(pokemon.favourite).to.be.true();
+      });
+    });
+
+    it('return a list of favourite Pokemon by name and type', async () => {
+      const givenPokemon = {
+        id: '006',
+        name: 'Charizard',
+        type: 'fire',
+      };
+      await client.put(
+        `/pokemon/${givenPokemon.id}/favourite/${FavouriteActions.Mark}`,
+      );
+      const res = await client
+        .get(
+          `/pokemon?name=${givenPokemon.name}&type=${givenPokemon.type}&favourite=true`,
+        )
+        .expect(200);
+      res.body.forEach((pokemon: Pokemon) => {
+        expect(pokemon.name).to.containEql(givenPokemon.name);
+        expect(pokemon.types).to.have.containEql(givenPokemon.type);
+        expect(pokemon.favourite).to.be.true();
+      });
+    });
   });
 
   describe('invokes GET /pokemon/{id}', () => {

--- a/src/controllers/pokemon.controller.ts
+++ b/src/controllers/pokemon.controller.ts
@@ -37,8 +37,9 @@ export class PokemonController {
   async find(
     @param.query.string('name') name?: string,
     @param.query.string('type') type?: string,
+    @param.query.boolean('favourite') favourite?: boolean,
   ): Promise<Pokemon[]> {
-    return this.pokemonService.findAll({name, type});
+    return this.pokemonService.findAll({name, type, favourite});
   }
 
   @get('/pokemon/{id}')

--- a/src/models/pokemon.model.ts
+++ b/src/models/pokemon.model.ts
@@ -97,6 +97,11 @@ export class Pokemon extends Entity {
   })
   previousEvolutions?: object;
 
+  @property({
+    type: 'boolean',
+  })
+  favourite?: boolean;
+
   [prop: string]: string | number | object | boolean | undefined;
 
   constructor(data?: Partial<Pokemon>) {

--- a/src/services/pokemon.service.ts
+++ b/src/services/pokemon.service.ts
@@ -16,12 +16,13 @@ export class PokemonService {
     public pokemonRepository: PokemonRepository,
   ) {}
 
-  findAll({name, type}: PokemonQueryParams): Promise<Pokemon[]> {
-    return name || type
+  findAll({name, type, favourite}: PokemonQueryParams): Promise<Pokemon[]> {
+    return name || type || favourite
       ? this.pokemonRepository.find({
           where: {
             name: {like: new RegExp('.*' + name + '.*', 'i')},
             types: type,
+            favourite,
           },
         })
       : this.pokemonRepository.find();


### PR DESCRIPTION
Filter pokemon list by favourite property and mix it with name and type
✅ define use cases to query pokemon by favourite query param and others
♻️ add explicitly the property favourite to use it on queries
✨ add favourite property at query on service
✨ add favourite query param at endpoint